### PR TITLE
Use SF Symbols for settings icons

### DIFF
--- a/Komet/Base.lproj/Preferences.xib
+++ b/Komet/Base.lproj/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,7 +31,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="855" y="378" width="317" height="191"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1710" height="1068"/>
             <view key="contentView" id="bQ0-fo-hiP">
                 <rect key="frame" x="0.0" y="0.0" width="317" height="191"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -49,20 +49,26 @@
             </view>
             <toolbar key="toolbar" implicitIdentifier="140A12A2-0776-449C-BCC2-DFC0429EE277" autosavesConfiguration="NO" displayMode="iconAndLabel" sizeMode="regular" id="gtZ-SJ-SSD">
                 <allowedToolbarItems>
-                    <toolbarItem implicitItemIdentifier="8BF32653-7CF4-4E59-BC05-2B4B3D7F0EBA" explicitItemIdentifier="fonts" label="fonts" paletteLabel="fonts" image="NSFontPanel" selectable="YES" id="ZSv-XI-2jR">
+                    <toolbarItem implicitItemIdentifier="8BF32653-7CF4-4E59-BC05-2B4B3D7F0EBA" explicitItemIdentifier="fonts" label="fonts" paletteLabel="fonts" image="textformat" catalog="system" selectable="YES" id="ZSv-XI-2jR">
                         <nil key="toolTip"/>
+                        <size key="minSize" width="44.5" height="26"/>
+                        <size key="maxSize" width="44.5" height="26"/>
                         <connections>
                             <action selector="showFonts:" target="-2" id="5sr-Gh-gMN"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="70411AE7-3839-4390-AD03-AFACA15E4648" explicitItemIdentifier="warnings" label="warnings" paletteLabel="warnings" tag="1" image="NSCaution" selectable="YES" id="YxA-vf-ITa">
+                    <toolbarItem implicitItemIdentifier="70411AE7-3839-4390-AD03-AFACA15E4648" explicitItemIdentifier="warnings" label="warnings" paletteLabel="warnings" tag="1" image="exclamationmark.triangle" catalog="system" selectable="YES" id="YxA-vf-ITa">
                         <nil key="toolTip"/>
+                        <size key="minSize" width="40.5" height="30"/>
+                        <size key="maxSize" width="40.5" height="30"/>
                         <connections>
                             <action selector="showWarnings:" target="-2" id="GX5-9y-7lK"/>
                         </connections>
                     </toolbarItem>
-                    <toolbarItem implicitItemIdentifier="54106575-5C4C-4A34-AEDE-9E90FEFB68CC" explicitItemIdentifier="advanced" label="advanced" paletteLabel="advanced" tag="3" image="NSAdvanced" selectable="YES" id="2Wj-Ck-alH">
+                    <toolbarItem implicitItemIdentifier="54106575-5C4C-4A34-AEDE-9E90FEFB68CC" explicitItemIdentifier="advanced" label="advanced" paletteLabel="advanced" tag="3" image="gearshape.2" catalog="system" selectable="YES" id="2Wj-Ck-alH">
                         <nil key="toolTip"/>
+                        <size key="minSize" width="48" height="33"/>
+                        <size key="maxSize" width="48" height="33"/>
                         <connections>
                             <action selector="showAdvanced:" target="-2" id="MqJ-c9-Kk4"/>
                         </connections>
@@ -80,11 +86,11 @@
             <point key="canvasLocation" x="270" y="-80.5"/>
         </window>
         <customView id="h9g-vJ-Iwb" userLabel="Fonts View">
-            <rect key="frame" x="0.0" y="0.0" width="268" height="137"/>
+            <rect key="frame" x="0.0" y="2" width="268" height="135"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="P9V-1A-nFH">
-                    <rect key="frame" x="20" y="78" width="143" height="22"/>
+                    <rect key="frame" x="20" y="77" width="143" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="message_font" drawsBackground="YES" id="S5K-Sz-QaX">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -92,7 +98,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pzu-Uy-F1z">
-                    <rect key="frame" x="165" y="71" width="89" height="32"/>
+                    <rect key="frame" x="164" y="70" width="91" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="77" id="PLB-f9-Glb"/>
                     </constraints>
@@ -105,7 +111,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ffs-GR-vmH">
-                    <rect key="frame" x="18" y="50" width="72" height="16"/>
+                    <rect key="frame" x="18" y="49" width="72" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="comments" id="8tv-N4-3C7">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -113,7 +119,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="800" translatesAutoresizingMaskIntoConstraints="NO" id="f8W-g8-7pY">
-                    <rect key="frame" x="20" y="20" width="143" height="22"/>
+                    <rect key="frame" x="20" y="20" width="143" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="comments_font" drawsBackground="YES" id="piI-Qf-pPu">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -121,7 +127,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9vQ-Qv-IvQ">
-                    <rect key="frame" x="18" y="108" width="62" height="16"/>
+                    <rect key="frame" x="18" y="106" width="62" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="message" id="xwO-UY-was">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -129,7 +135,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="viz-io-HRY">
-                    <rect key="frame" x="165" y="13" width="89" height="32"/>
+                    <rect key="frame" x="164" y="13" width="91" height="32"/>
                     <buttonCell key="cell" type="push" title="select" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="N1Z-Bs-8Wg">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -169,7 +175,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jy8-sf-kAO">
-                    <rect key="frame" x="18" y="70" width="142" height="16"/>
+                    <rect key="frame" x="18" y="70" width="145" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="highlight_text_exceeds" id="A0E-bX-VpF">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -177,7 +183,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xcy-hC-F81">
-                    <rect key="frame" x="52" y="41" width="52" height="21"/>
+                    <rect key="frame" x="52" y="41" width="47" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="gzs-t9-ZE6"/>
                     </constraints>
@@ -195,7 +201,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="T4H-cy-4ps">
-                    <rect key="frame" x="110" y="44" width="189" height="16"/>
+                    <rect key="frame" x="105" y="44" width="194" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="characters_on_first_line" id="v8K-FZ-wmd">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -203,7 +209,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="J5L-oh-zfQ">
-                    <rect key="frame" x="52" y="16" width="52" height="21"/>
+                    <rect key="frame" x="52" y="16" width="47" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" enabled="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="72" drawsBackground="YES" id="GaT-02-duj">
                         <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="sK3-gF-EeY">
                             <real key="minimum" value="1"/>
@@ -218,7 +224,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SFd-F9-BRj">
-                    <rect key="frame" x="110" y="19" width="189" height="16"/>
+                    <rect key="frame" x="105" y="19" width="194" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="characters_on_remaining_lines" id="sJ5-gB-Uf8">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -275,11 +281,11 @@
             <point key="canvasLocation" x="273.5" y="333"/>
         </customView>
         <customView id="E8X-F5-Lbv" userLabel="Advanced View">
-            <rect key="frame" x="0.0" y="0.0" width="296" height="94"/>
+            <rect key="frame" x="0.0" y="-2" width="296" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="c3p-Oz-hOG">
-                    <rect key="frame" x="18" y="58" width="260" height="18"/>
+                    <rect key="frame" x="18" y="61" width="258" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="WBU-Hc-14f"/>
                     </constraints>
@@ -292,7 +298,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JJc-Hj-X94">
-                    <rect key="frame" x="18" y="38" width="260" height="18"/>
+                    <rect key="frame" x="18" y="39" width="258" height="18"/>
                     <buttonCell key="cell" type="check" title="resume_last_session" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="G3b-Vh-CFP">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -302,7 +308,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="4aw-Oh-wqh">
-                    <rect key="frame" x="18" y="18" width="260" height="18"/>
+                    <rect key="frame" x="18" y="19" width="258" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="lc4-mW-1RR"/>
                     </constraints>
@@ -333,8 +339,8 @@
         </customView>
     </objects>
     <resources>
-        <image name="NSAdvanced" width="32" height="32"/>
-        <image name="NSCaution" width="32" height="32"/>
-        <image name="NSFontPanel" width="32" height="32"/>
+        <image name="exclamationmark.triangle" catalog="system" width="17" height="15"/>
+        <image name="gearshape.2" catalog="system" width="20" height="16"/>
+        <image name="textformat" catalog="system" width="18" height="12"/>
     </resources>
 </document>


### PR DESCRIPTION
Symbolic icons are used by system apps

<img width="429" alt="Screenshot 2023-09-12 at 1 15 44 PM" src="https://github.com/zorgiepoo/Komet/assets/63008755/f10df1e8-2406-4b0e-b961-523f446bbf6f">



<img width="489" alt="Screenshot 2023-09-12 at 1 30 57 PM" src="https://github.com/zorgiepoo/Komet/assets/63008755/fc829f8c-a31d-4d9c-b064-e2b8951e1b5c">
