### PR TITLE
Escape editor path in tutorial

### DIFF
--- a/Komet.xcodeproj/project.pbxproj
+++ b/Komet.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		72D3BE86254FDB6A0051914F /* UpdaterSettingsListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D3BE85254FDB6A0051914F /* UpdaterSettingsListener.swift */; };
 		72D3BE8A25564D420051914F /* UpdaterUserDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D3BE8925564D420051914F /* UpdaterUserDriver.swift */; };
 		72D3BE8E25565CDC0051914F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D3BE8D25565CDC0051914F /* main.swift */; };
+		A79E145C2D7C53F300F93FD1 /* String+escaping.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79E145B2D7C536A00F93FD1 /* String+escaping.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -116,6 +117,7 @@
 		72D3BE8D25565CDC0051914F /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		772B7CCB21437E2500E993B2 /* Komet.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Komet.entitlements; sourceTree = "<group>"; };
 		77C23E5E232CB41800F5BC6C /* KometDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KometDebug.entitlements; sourceTree = "<group>"; };
+		A79E145B2D7C536A00F93FD1 /* String+escaping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+escaping.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -212,6 +214,7 @@
 				726F32F51DE27AB7004FB4AF /* Credits.rtf */,
 				723606B01FC630C400BDD6E9 /* Localizable.strings */,
 				72B72C981D63EFF90096365F /* Supporting Files */,
+				A79E145B2D7C536A00F93FD1 /* String+escaping.swift */,
 			);
 			path = Komet;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				72D3BE8E25565CDC0051914F /* main.swift in Sources */,
 				72D3BE79254F24CF0051914F /* WindowStyleTheme.swift in Sources */,
 				7272EB4D25588DC900C78C4D /* WindowStyleDefaultTheme.swift in Sources */,
+				A79E145C2D7C53F300F93FD1 /* String+escaping.swift in Sources */,
 				72D3BE81254FD56F0051914F /* UpdaterController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Komet/AppDelegate.swift
+++ b/Komet/AppDelegate.swift
@@ -131,6 +131,11 @@ typealias StatFS = statfs
 				}
 			}
 			
+			let escapedEditorPathToUse =
+				editorPathToUse
+					.escapingGitConfigBreakingCharacters // escape for parsing by Git
+					.doubleQuoteDelimited // escape for parsing by shell
+			
 			let editorConfigurationRecommendation: String
 			do {
 				let tutorialDefaultGitEditorRecommendation = NSLocalizedString("tutorialDefaultGitEditorRecommendation", tableName: nil, comment: "")
@@ -144,7 +149,7 @@ typealias StatFS = statfs
 				#
 				# \(tutorialDefaultGitEditorRecommendation)
 				#
-				# git config --global core.editor "\(editorPathToUse)"
+				# git config --global core.editor \(escapedEditorPathToUse)
 				#
 				# \(tutorialDefaultHgEditorRecommendation)
 				# \(tutorialDefaultSvnEditorRecommendation)

--- a/Komet/String+escaping.swift
+++ b/Komet/String+escaping.swift
@@ -1,0 +1,31 @@
+//
+//  String+escaping.swift
+//  Komet
+//
+//  Created by Nathan Manceaux-Panot on 2025-03-08.
+//  Copyright © 2025 zgcoder. All rights reserved.
+//
+
+import Foundation
+
+fileprivate let singleQuote = "'"
+fileprivate let doubleQuote = "\""
+fileprivate let antiSlash = "\\"
+
+extension String {
+	var escapingGitConfigBreakingCharacters: String {
+		self
+			.replacingOccurrences(of: antiSlash, with: antiSlash + antiSlash)
+			.replacingOccurrences(of: singleQuote, with: antiSlash + singleQuote)
+			.replacingOccurrences(of: doubleQuote, with: antiSlash + doubleQuote)
+			.replacingOccurrences(of: " ", with: antiSlash + " ")
+	}
+	
+	var doubleQuoteDelimited: String {
+		doubleQuote
+		+ self
+			.replacingOccurrences(of: antiSlash, with: antiSlash + antiSlash)
+			.replacingOccurrences(of: doubleQuote, with: antiSlash + doubleQuote)
+		+ doubleQuote
+	}
+}


### PR DESCRIPTION
Komet's tutorial helpfully gives a ready-to-use command to setup Git. However, if the path to the application contains some special characters (` `, `"`, or `'`), the command fails.

This PR fixes this issue by escaping the path. First, an escape so that the string written to the config is correctly parsed by Git; and second, an escape so that the shell correctly parses the command in the first place.

I'm not sure how the String extension fits within Komet's code style. Feel free to change anything or suggest any change, or course!